### PR TITLE
Focus Tab on Notification Click for Content Tracker

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,14 +5,30 @@ chrome.webNavigation.onCommitted.addListener((details) => {
   }
 });
 
-chrome.runtime.onMessage.addListener((request) => {
+let lastNotifiedTabId = null; // Store the tab ID for the notification
+chrome.runtime.onMessage.addListener((request, sender) => {
   if (request.action === "notify") {
+    // Store the tab ID from which the notification was triggered
+    lastNotifiedTabId = sender.tab.id;
+
     // Create a notification to alert the user
     chrome.notifications.create({
       type: "basic",
       iconUrl: "bell-icon.png",
       title: "Content Alert!",
-      message: `The content "${request.message}" has appeared!`
+      message: `The content "${request.message}" has appeared!`,
+      requireInteraction: true, // Keeps the notification active until clicked/dismissed
     });
+  }
+});
+
+chrome.notifications.onClicked.addListener((notificationId) => {
+  if (lastNotifiedTabId !== null) {
+    // Focus on the tab from which the notification was triggered
+    chrome.tabs.update(lastNotifiedTabId, { active: true });
+    // Bring the Chrome window to the foreground
+    chrome.windows.update(chrome.windows.WINDOW_ID_CURRENT, { focused: true });
+    // Clear the notification
+    chrome.notifications.clear(notificationId);
   }
 });


### PR DESCRIPTION
## This PR implements the following improvements:

- Adds functionality to focus back on the tab that triggered the content notification when the notification is clicked.
- Stores the tabId of the originating tab when the notification is pushed.
- Ensures that clicking the notification brings the Chrome window to the foreground and focuses on the correct tab.
- The notification is kept active until the user interacts with it, ensuring the user doesn’t miss the alert.

This change improves user experience by allowing immediate focus on the relevant tab when a content alert is triggered.